### PR TITLE
Fix: Unique name for 'Rosé Pine Dawn'

### DIFF
--- a/themes/rose-pine-dawn.json
+++ b/themes/rose-pine-dawn.json
@@ -3,12 +3,12 @@
     "\"UTF.8\"": true
   },
   "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
-  "name": "Rosé Pine",
+  "name": "Rosé Pine Dawn",
   "author": "Kainoa Kanter <kainoa@t1c.dev>",
   "themes": [
     {
       "appearance": "dark",
-      "name": "Rosé Pine",
+      "name": "Rosé Pine Dawn",
       "style": {
         "editor.foreground": "#575279",
         "editor.background": "#faf4ed",


### PR DESCRIPTION
Possible fix for standard "Rosé Pine" theme not working when installed via Zed extension manager (#2)