### PR TITLE
Fix description

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -1,9 +1,9 @@
 {
     "name": "Rosé Pine",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "authors": [
         "Kainoa Kanter <kainoa@t1c.dev>"
     ],
-    "description": "soho vibes for zed",
+    "description": "Theme soho vibes for zed",
     "repository": "https://github.com/rose-pine/zed"
 }

--- a/extension.json
+++ b/extension.json
@@ -4,6 +4,6 @@
     "authors": [
         "Kainoa Kanter <kainoa@t1c.dev>"
     ],
-    "description": "Theme soho vibes for zed",
+    "description": "All natural pine, faux fur, and a bit of soho vibes – a classy minimalist theme for Zed.",
     "repository": "https://github.com/rose-pine/zed"
 }


### PR DESCRIPTION
By analyzing the extensions at the moment there is no way to understand if an extension is a theme or something else.
There is no filter that allows you to do this.

Adding the words theme to the description could help you better understand what it is about.

If not, you need to open the repository to understand it.

<img width="273" alt="Screenshot 2024-06-13 alle 11 43 17" src="https://github.com/rose-pine/zed/assets/20476002/4019e53e-8c2d-40b4-9fc3-e9e09f718d1a">
