### PR TITLE
Adjust text color to match Rosé Pine text color

### DIFF
--- a/src/rose-pine-dawn.scss
+++ b/src/rose-pine-dawn.scss
@@ -82,7 +82,7 @@ themes {
       --border-disabled: #{$background-high-contrast};
 
       /* Text */
-      --text: #{$foreground-high-contrast};
+      --text: #{$foreground-higher-contrast};
       --text-muted: #{$foreground-high-contrast};
       --text-placeholder: #{$foreground-lower-contrast};
       --text-disabled: #{$foreground-lower-contrast};

--- a/src/rose-pine-moon.scss
+++ b/src/rose-pine-moon.scss
@@ -82,7 +82,7 @@ themes {
       --border-disabled: #{$background-high-contrast};
 
       /* Text */
-      --text: #{$foreground-high-contrast};
+      --text: #{$foreground-higher-contrast};
       --text-muted: #{$foreground-high-contrast};
       --text-placeholder: #{$foreground-lower-contrast};
       --text-disabled: #{$foreground-lower-contrast};

--- a/src/rose-pine.scss
+++ b/src/rose-pine.scss
@@ -82,7 +82,7 @@ themes {
       --border-disabled: #{$background-high-contrast};
 
       /* Text */
-      --text: #{$foreground-high-contrast};
+      --text: #{$foreground-higher-contrast};
       --text-muted: #{$foreground-high-contrast};
       --text-placeholder: #{$foreground-lower-contrast};
       --text-disabled: #{$foreground-lower-contrast};

--- a/themes/rose-pine-dawn.json
+++ b/themes/rose-pine-dawn.json
@@ -25,7 +25,7 @@
         "border.selected": "#faf4ed",
         "border.transparent": "#faf4ed",
         "border.disabled": "#faf4ed",
-        "text": "#9893a5",
+        "text": "#575279",
         "text.muted": "#9893a5",
         "text.placeholder": "#dfdad9",
         "text.disabled": "#dfdad9",

--- a/themes/rose-pine-moon.json
+++ b/themes/rose-pine-moon.json
@@ -25,7 +25,7 @@
         "border.selected": "#232136",
         "border.transparent": "#232136",
         "border.disabled": "#232136",
-        "text": "#6e6a86",
+        "text": "#e0def4",
         "text.muted": "#6e6a86",
         "text.placeholder": "#44415a",
         "text.disabled": "#44415a",

--- a/themes/rose-pine.json
+++ b/themes/rose-pine.json
@@ -25,7 +25,7 @@
         "border.selected": "#21202e",
         "border.transparent": "#21202e",
         "border.disabled": "#21202e",
-        "text": "#6e6a86",
+        "text": "#e0def4",
         "text.muted": "#6e6a86",
         "text.placeholder": "#403d52",
         "text.disabled": "#403d52",


### PR DESCRIPTION
This resolves changing text from Rose Pine Muted Text to Rose Pine Text for each theme.

**Rose Piné Before**
<img width="601" alt="Screenshot 2024-08-13 at 2 19 52 PM" src="https://github.com/user-attachments/assets/df8fbbcb-8800-4457-952d-a6d228907b20">

**Rose Piné After**
<img width="574" alt="Screenshot 2024-08-13 at 2 41 53 PM" src="https://github.com/user-attachments/assets/d6f4ba94-d0e2-4325-b14a-109a875d971a">

**Rose Piné Moon Before**
<img width="566" alt="Screenshot 2024-08-13 at 2 47 23 PM" src="https://github.com/user-attachments/assets/3bcc6862-48e3-4c8b-b750-a647cbc56525">

**Rose Piné Moon After**
<img width="563" alt="Screenshot 2024-08-13 at 2 47 31 PM" src="https://github.com/user-attachments/assets/462465d7-d305-456e-b8ba-94e5e15ad78b">

**Rose Piné Dawn Before**
<img width="564" alt="Screenshot 2024-08-13 at 2 47 49 PM" src="https://github.com/user-attachments/assets/6c8893b9-074c-44d1-a26d-d7cd2d44a01d">

**Rose Piné Dawn After**
<img width="586" alt="Screenshot 2024-08-13 at 2 48 12 PM" src="https://github.com/user-attachments/assets/8c23add0-feaa-4b50-bf40-7f852e9851ea">

Resolves #8