### PR TITLE
Edit panel.focused_border colors to be more visible

### DIFF
--- a/src/template.json
+++ b/src/template.json
@@ -38,7 +38,7 @@
 				"surface.background": "$surface",
 				"elevated_surface.background": "$surface",
 				"panel.background": "$base",
-				"panel.focused_border": "$surface",
+				"panel.focused_border": "$highlightHigh",
 				"background": "$base",
 				"status_bar.background": "$base",
 				"title_bar.background": "$base",

--- a/src/template.json
+++ b/src/template.json
@@ -38,7 +38,7 @@
 				"surface.background": "$surface",
 				"elevated_surface.background": "$surface",
 				"panel.background": "$base",
-				"panel.focused_border": "$highlightHigh",
+				"panel.focused_border": "$iris44",
 				"background": "$base",
 				"status_bar.background": "$base",
 				"title_bar.background": "$base",

--- a/themes/rose-pine-dawn.json
+++ b/themes/rose-pine-dawn.json
@@ -38,7 +38,7 @@
 				"surface.background": "#fffaf3",
 				"elevated_surface.background": "#fffaf3",
 				"panel.background": "#faf4ed",
-				"panel.focused_border": "#cecacd",
+				"panel.focused_border": "#907aa944",
 				"background": "#faf4ed",
 				"status_bar.background": "#faf4ed",
 				"title_bar.background": "#faf4ed",

--- a/themes/rose-pine-dawn.json
+++ b/themes/rose-pine-dawn.json
@@ -38,7 +38,7 @@
 				"surface.background": "#fffaf3",
 				"elevated_surface.background": "#fffaf3",
 				"panel.background": "#faf4ed",
-				"panel.focused_border": "#fffaf3",
+				"panel.focused_border": "#cecacd",
 				"background": "#faf4ed",
 				"status_bar.background": "#faf4ed",
 				"title_bar.background": "#faf4ed",

--- a/themes/rose-pine-moon.json
+++ b/themes/rose-pine-moon.json
@@ -38,7 +38,7 @@
 				"surface.background": "#2a273f",
 				"elevated_surface.background": "#2a273f",
 				"panel.background": "#232136",
-				"panel.focused_border": "#56526e",
+				"panel.focused_border": "#c4a7e744",
 				"background": "#232136",
 				"status_bar.background": "#232136",
 				"title_bar.background": "#232136",

--- a/themes/rose-pine-moon.json
+++ b/themes/rose-pine-moon.json
@@ -38,7 +38,7 @@
 				"surface.background": "#2a273f",
 				"elevated_surface.background": "#2a273f",
 				"panel.background": "#232136",
-				"panel.focused_border": "#2a273f",
+				"panel.focused_border": "#56526e",
 				"background": "#232136",
 				"status_bar.background": "#232136",
 				"title_bar.background": "#232136",

--- a/themes/rose-pine.json
+++ b/themes/rose-pine.json
@@ -38,7 +38,7 @@
 				"surface.background": "#1f1d2e",
 				"elevated_surface.background": "#1f1d2e",
 				"panel.background": "#191724",
-				"panel.focused_border": "#524f67",
+				"panel.focused_border": "#c4a7e744",
 				"background": "#191724",
 				"status_bar.background": "#191724",
 				"title_bar.background": "#191724",

--- a/themes/rose-pine.json
+++ b/themes/rose-pine.json
@@ -38,7 +38,7 @@
 				"surface.background": "#1f1d2e",
 				"elevated_surface.background": "#1f1d2e",
 				"panel.background": "#191724",
-				"panel.focused_border": "#1f1d2e",
+				"panel.focused_border": "#524f67",
 				"background": "#191724",
 				"status_bar.background": "#191724",
 				"title_bar.background": "#191724",


### PR DESCRIPTION
I use keyboard navigation quite a lot within the project panel and the current focus borders make it very hard to tell what I have focused. This was an issue in all three palettes. I chose the "Highlight High" color to fix this for each.

Updated colors:
![Rose Pine Example](https://github.com/user-attachments/assets/ce83bb84-e445-43e6-b311-9098a8047828)
![Rose Pine Moon Example](https://github.com/user-attachments/assets/3222a161-2f78-418a-9a33-6dbe29cf184d)
![Rose Pine Dawn Example](https://github.com/user-attachments/assets/f2c18e2c-5cc5-46a4-aee7-df486a3aaec7)

