### PR TITLE
fix title_bar.inactive_background key being null.

### DIFF
--- a/src/template.json
+++ b/src/template.json
@@ -44,6 +44,7 @@
                 "background": "$base",
                 "status_bar.background": "$base",
                 "title_bar.background": "$base",
+                "title_bar.inactive_background": "$base",
                 "toolbar.background": "$base",
                 "tab_bar.background": "$surface",
                 "tab.inactive_background": "$surface",

--- a/themes/rose-pine-dawn.json
+++ b/themes/rose-pine-dawn.json
@@ -44,6 +44,7 @@
                 "background": "#faf4ed",
                 "status_bar.background": "#faf4ed",
                 "title_bar.background": "#faf4ed",
+                "title_bar.inacitve_background": "#faf4ed",
                 "toolbar.background": "#faf4ed",
                 "tab_bar.background": "#fffaf3",
                 "tab.inactive_background": "#fffaf3",

--- a/themes/rose-pine-dawn.json
+++ b/themes/rose-pine-dawn.json
@@ -44,7 +44,7 @@
                 "background": "#faf4ed",
                 "status_bar.background": "#faf4ed",
                 "title_bar.background": "#faf4ed",
-                "title_bar.inacitve_background": "#faf4ed",
+                "title_bar.inactive_background": "#faf4ed",
                 "toolbar.background": "#faf4ed",
                 "tab_bar.background": "#fffaf3",
                 "tab.inactive_background": "#fffaf3",

--- a/themes/rose-pine-moon.json
+++ b/themes/rose-pine-moon.json
@@ -44,6 +44,7 @@
                 "background": "#232136",
                 "status_bar.background": "#232136",
                 "title_bar.background": "#232136",
+                "title_bar.inactive_background": "#232136",
                 "toolbar.background": "#232136",
                 "tab_bar.background": "#2a273f",
                 "tab.inactive_background": "#2a273f",

--- a/themes/rose-pine.json
+++ b/themes/rose-pine.json
@@ -44,6 +44,7 @@
                 "background": "#191724",
                 "status_bar.background": "#191724",
                 "title_bar.background": "#191724",
+                "title_bar.inactive_background": "#191724",
                 "toolbar.background": "#191724",
                 "tab_bar.background": "#1f1d2e",
                 "tab.inactive_background": "#1f1d2e",


### PR DESCRIPTION
Issue: On window being inactive, the title bar will show un-skinned being 'gray'.

Fix: The new value in Zed themes, ``title_bar.inactive_background:`` was not given a value, and/ or has not existed.

