### PR TITLE
fix: set merge conflict bg color

### DIFF
--- a/src/template.json
+++ b/src/template.json
@@ -134,6 +134,8 @@
                 "version_control.conflict": "$rose",
                 "version_control.renamed": "$iris",
                 "version_control.ignored": "$muted",
+                "version_control.conflict_marker.ours": "$gold33",
+                "version_control.conflict_marker.theirs": "$foam33",
                 "players": [
                     {
                         "cursor": "$text",

--- a/themes/rose-pine-dawn.json
+++ b/themes/rose-pine-dawn.json
@@ -134,6 +134,8 @@
                 "version_control.conflict": "#d7827e",
                 "version_control.renamed": "#907aa9",
                 "version_control.ignored": "#9893a5",
+                "version_control.conflict_marker.ours": "#ea9d3433",
+                "version_control.conflict_marker.theirs": "#56949f33",
                 "players": [
                     {
                         "cursor": "#575279",

--- a/themes/rose-pine-moon.json
+++ b/themes/rose-pine-moon.json
@@ -134,6 +134,8 @@
                 "version_control.conflict": "#ea9a97",
                 "version_control.renamed": "#c4a7e7",
                 "version_control.ignored": "#6e6a86",
+                "version_control.conflict_marker.ours": "#f6c17733",
+                "version_control.conflict_marker.theirs": "#9ccfd833",
                 "players": [
                     {
                         "cursor": "#e0def4",

--- a/themes/rose-pine.json
+++ b/themes/rose-pine.json
@@ -134,6 +134,8 @@
                 "version_control.conflict": "#ebbcba",
                 "version_control.renamed": "#c4a7e7",
                 "version_control.ignored": "#6e6a86",
+                "version_control.conflict_marker.ours": "#f6c17733",
+                "version_control.conflict_marker.theirs": "#9ccfd833",
                 "players": [
                     {
                         "cursor": "#e0def4",


### PR DESCRIPTION
### Problem

Merge conflict highlighting currently falls back to default colors, which doesn't fit with the theme palette.

<img width="1258" height="576" alt="1761343295_screenshot" src="https://github.com/user-attachments/assets/424e4685-6226-4532-9356-b26f40719b3c" />


### Solution
Set `version_control.conflict_marker.ours` and `version_control.conflict_marker.theirs` colors.
Using the same colors as in VSCode theme results in this:

<img width="1258" height="525" alt="1761344022_screenshot" src="https://github.com/user-attachments/assets/0c8e36ab-cfaa-476c-bcd8-382cc4fb3a8b" />

However, colors are too bright and made text hard to read (notice line numbers, punctuation). This PR uses more transparent variants for better readability:

<img width="1342" height="568" alt="1761347920_screenshot" src="https://github.com/user-attachments/assets/626411a1-e4e8-46ce-a490-cbb24d8f3489" />

Blocked by: https://github.com/rose-pine/vscode/pull/114